### PR TITLE
 cm: Include librsjni explicitly

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -66,6 +66,10 @@ PRODUCT_PACKAGES += \
     Development \
     SpareParts \
     su
+    
+    # Include librsjni explicitly to workaround GMS issue
+PRODUCT_PACKAGES += \
+    librsjni
 
 # Optional packages
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
- Make sure this gets included since GMS webview breaks the dependency.
